### PR TITLE
feat prefixed time range for graph

### DIFF
--- a/app/components/device-detail/fixed-time-range-buttons.tsx
+++ b/app/components/device-detail/fixed-time-range-buttons.tsx
@@ -1,0 +1,74 @@
+import { useSearchParams, useSubmit } from "@remix-run/react";
+import { Badge } from "../ui/badge";
+import { subDays } from "date-fns";
+
+export default function FixedTimeRangeButtons() {
+  // Form submission handler
+  const submit = useSubmit();
+  const [searchParams] = useSearchParams();
+
+  const isLast24Hours =
+    searchParams.get("date_from") === subDays(new Date(), 1).toDateString() &&
+    searchParams.get("date_to") === new Date().toDateString();
+
+  const isLastWeek =
+    searchParams.get("date_from") === subDays(new Date(), 7).toDateString() &&
+    searchParams.get("date_to") === new Date().toDateString();
+
+  const isLastMonth =
+    searchParams.get("date_from") === subDays(new Date(), 30).toDateString() &&
+    searchParams.get("date_to") === new Date().toDateString();
+
+  function getLast24Hours() {
+    searchParams.set("date_from", subDays(new Date(), 1).toDateString());
+    searchParams.set("date_to", new Date().toDateString());
+
+    submit(searchParams, {
+      method: "get",
+    });
+  }
+
+  function getLastWeek() {
+    searchParams.set("date_from", subDays(new Date(), 7).toDateString());
+    searchParams.set("date_to", new Date().toDateString());
+
+    submit(searchParams, {
+      method: "get",
+    });
+  }
+
+  function getLastMonth() {
+    searchParams.set("date_from", subDays(new Date(), 30).toDateString());
+    searchParams.set("date_to", new Date().toDateString());
+
+    submit(searchParams, {
+      method: "get",
+    });
+  }
+
+  return (
+    <div className="flex cursor-pointer items-center justify-center gap-2 h-full">
+      <Badge
+        onClick={getLast24Hours}
+        variant="outline"
+        className={isLast24Hours ? "text-green-300" : ""}
+      >
+        24 hours
+      </Badge>
+      <Badge
+        onClick={getLastWeek}
+        variant="outline"
+        className={isLastWeek ? "text-green-300" : ""}
+      >
+        1 week
+      </Badge>
+      <Badge
+        onClick={getLastMonth}
+        variant="outline"
+        className={isLastMonth ? "text-green-300" : ""}
+      >
+        1 month
+      </Badge>
+    </div>
+  );
+}

--- a/app/components/device-detail/graph.tsx
+++ b/app/components/device-detail/graph.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { datesHave48HourRange } from "~/lib/utils";
+import FixedTimeRangeButtons from "./fixed-time-range-buttons";
 
 // Registering Chart.js components that will be used in the graph
 ChartJS.register(
@@ -244,7 +245,10 @@ export default function Graph(props: any) {
               className="flex cursor-move items-center justify-between px-2 pt-2"
               id="graphTop"
             >
-              <DatePickerGraph />
+              <div className="flex items-center justify-center gap-4">
+                <DatePickerGraph />
+                <FixedTimeRangeButtons />
+              </div>
               <div className="flex items-center justify-end gap-4">
                 <DropdownMenu>
                   <DropdownMenuTrigger>


### PR DESCRIPTION
- added 1 day, 1 week and 1 month for now
- this just sets the search params `date_from` and `date_to` according to the users choice
- it also checks if a specific time range has already been selected and highlights it