### PR TITLE
feat: add integrations

### DIFF
--- a/app/schema/device.ts
+++ b/app/schema/device.ts
@@ -16,6 +16,7 @@ import {
 import { user } from "./user";
 import { sensor } from "./sensor";
 import { logEntry } from "./log-entry";
+import { deviceToIntegrations } from "./integration";
 
 /**
  * Table
@@ -55,6 +56,10 @@ export const deviceRelations = relations(device, ({ one, many }) => ({
   }),
   sensors: many(sensor),
   logEntries: many(logEntry),
+  integrations: one(deviceToIntegrations, {
+    fields: [device.id],
+    references: [deviceToIntegrations.deviceId],
+  }),
 }));
 
 /**

--- a/app/schema/enum.ts
+++ b/app/schema/enum.ts
@@ -9,6 +9,23 @@ export const DeviceExposureEnum = pgEnum("exposure", [
   "unknown",
 ]);
 
+export const MqttMessageFormatEnum = pgEnum("message_format", [
+  "json",
+  "csv",
+  "application/json",
+  "text/csv",
+  "debug_plain",
+  "",
+]);
+
+export const TtnProfileEnum = pgEnum("ttn_profile", [
+  "json",
+  "debug",
+  "sensebox/home",
+  "lora-serialization",
+  "cayenne-lpp",
+]);
+
 // Zod schema for validating device exposure types
 export const DeviceExposureZodEnum = z.enum(DeviceExposureEnum.enumValues);
 
@@ -16,11 +33,7 @@ export const DeviceExposureZodEnum = z.enum(DeviceExposureEnum.enumValues);
 export type DeviceExposureType = z.infer<typeof DeviceExposureZodEnum>;
 
 // Enum for device status types
-export const DeviceStatusEnum = pgEnum("status", [
-  "active",
-  "inactive",
-  "old",
-]);
+export const DeviceStatusEnum = pgEnum("status", ["active", "inactive", "old"]);
 
 // Zod schema for validating device status types
 export const DeviceStatusZodEnum = z.enum(DeviceStatusEnum.enumValues);

--- a/app/schema/index.ts
+++ b/app/schema/index.ts
@@ -8,3 +8,4 @@ export * from "./types";
 export * from "./sensor";
 export * from "./user";
 export * from "./log-entry";
+export * from "./integration";

--- a/app/schema/integration.ts
+++ b/app/schema/integration.ts
@@ -2,13 +2,14 @@ import { createId } from "@paralleldrive/cuid2";
 import {
   boolean,
   integer,
+  json,
   pgTable,
   primaryKey,
   text,
 } from "drizzle-orm/pg-core";
 import { MqttMessageFormatEnum, TtnProfileEnum } from "./enum";
 import { device } from "./device";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 export const mqttIntegration = pgTable("mqtt_integration", {
   id: text("id")
@@ -21,8 +22,8 @@ export const mqttIntegration = pgTable("mqtt_integration", {
   messageFormat: MqttMessageFormatEnum("message_format")
     .default("json")
     .notNull(),
-  decodeOptions: text("decode_options").notNull(),
-  connectionOptions: text("connection_options").notNull(),
+  decodeOptions: json("decode_options"),
+  connectionOptions: json("connection_options"),
   deviceId: text("device_id").references(() => device.id, {
     onDelete: "cascade",
   }),
@@ -38,7 +39,9 @@ export const ttnIntegration = pgTable("ttn_integration", {
   appId: text("app_id").notNull(),
   port: integer("port"),
   profile: TtnProfileEnum("profile").default("json").notNull(),
-  decodeOptions: text("decode_options").notNull(),
+  decodeOptions: json("decode_options")
+    .$type<string[]>()
+    .default(sql`'{}'::json`),
   deviceId: text("device_id").references(() => device.id, {
     onDelete: "cascade",
   }),

--- a/app/schema/integration.ts
+++ b/app/schema/integration.ts
@@ -1,0 +1,83 @@
+import { createId } from "@paralleldrive/cuid2";
+import {
+  boolean,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+} from "drizzle-orm/pg-core";
+import { MqttMessageFormatEnum, TtnProfileEnum } from "./enum";
+import { device } from "./device";
+import { relations } from "drizzle-orm";
+
+export const mqttIntegration = pgTable("mqtt_integration", {
+  id: text("id")
+    .primaryKey()
+    .notNull()
+    .$defaultFn(() => createId()),
+  enabled: boolean("enabled").default(false).notNull(),
+  url: text("url").notNull(),
+  topic: text("topic").notNull(),
+  messageFormat: MqttMessageFormatEnum("message_format")
+    .default("json")
+    .notNull(),
+  decodeOptions: text("decode_options").notNull(),
+  connectionOptions: text("connection_options").notNull(),
+  deviceId: text("device_id").references(() => device.id, {
+    onDelete: "cascade",
+  }),
+});
+
+export const ttnIntegration = pgTable("ttn_integration", {
+  id: text("id")
+    .primaryKey()
+    .notNull()
+    .$defaultFn(() => createId()),
+  enabled: boolean("enabled").default(false).notNull(),
+  devId: text("dev_id").notNull(),
+  appId: text("app_id").notNull(),
+  port: integer("port"),
+  profile: TtnProfileEnum("profile").default("json").notNull(),
+  decodeOptions: text("decode_options").notNull(),
+  deviceId: text("device_id").references(() => device.id, {
+    onDelete: "cascade",
+  }),
+});
+
+export const deviceToIntegrations = pgTable(
+  "device_to_integrations",
+  {
+    deviceId: text("device_id")
+      .notNull()
+      .references(() => device.id, { onDelete: "cascade" }),
+    mqttIntegrationId: text("mqtt_integration_id").references(
+      () => mqttIntegration.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+    ttnIntegrationId: text("ttn_integration_id").references(
+      () => ttnIntegration.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.deviceId] }),
+  }),
+);
+
+export const deviceToIntegrationsRelations = relations(
+  deviceToIntegrations,
+  ({ one }) => ({
+    mqttIntegration: one(mqttIntegration, {
+      fields: [deviceToIntegrations.mqttIntegrationId],
+      references: [mqttIntegration.id],
+    }),
+    ttnIntegration: one(ttnIntegration, {
+      fields: [deviceToIntegrations.ttnIntegrationId],
+      references: [ttnIntegration.id],
+    }),
+  }),
+);


### PR DESCRIPTION
This pull request introduces several notable changes to the schema definitions and relationships in the codebase, primarily adding new integrations and enums. The key changes are summarized below:

### Schema Enhancements:

* Added a new import for `deviceToIntegrations` in the `device` schema file to establish relationships with integrations.

### Relationship Additions:

* Updated `deviceRelations` to include a one-to-one relationship with `deviceToIntegrations`, linking devices to their respective integrations.

### Enum Definitions:

* Introduced `MqttMessageFormatEnum` and `TtnProfileEnum` enums to support different message formats and profiles for integrations.

### Integration Schema:

* Added a new file `integration.ts` defining the schema for `mqttIntegration`, `ttnIntegration`, and `deviceToIntegrations`, including their relationships and constraints.

### Export Updates:

* Updated the `index.ts` file to export the new `integration` schema, making it accessible throughout the application.