### PR TITLE
chore: remove old express prometheus middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "drizzle-orm": "^0.38.3",
         "execa": "^9.4.0",
         "express": "^4.18.2",
-        "express-prometheus-middleware": "^1.2.0",
         "flubber": "^0.4.2",
         "framer-motion": "^11.16.0",
         "geolib": "^3.3.4",
@@ -11641,23 +11640,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-prometheus-middleware": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/express-prometheus-middleware/-/express-prometheus-middleware-1.2.0.tgz",
-      "integrity": "sha512-efSwft67rdtiW40D0im1f7Rz1TCGHGzPj6lfK0MxZDcPj6z4f/Ab5VNkWPYZEjvLqZiZ7fbS00CYzpigO8tS+g==",
-      "license": "MIT",
-      "dependencies": {
-        "response-time": "^2.3.2",
-        "url-value-parser": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "prometheus-gc-stats": "^0.6.2"
-      },
-      "peerDependencies": {
-        "express": "4.x",
-        "prom-client": ">= 10.x <= 13.x"
-      }
-    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -12237,22 +12219,6 @@
       "integrity": "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/gc-stats": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.1.tgz",
-      "integrity": "sha512-eAvDBpI6UjVIYwLxshPCJJIkPyfamIrJzBtW/103+ooJWkISS+chVnHNnsZ+ubaw2607rFeiRDNWHkNUA+ioqg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "hasInstallScript": true,
-      "license": "Unlicense",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.18.0",
-        "node-gyp-build": "^4.8.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/gensync": {
@@ -15585,13 +15551,6 @@
         "thenify-all": "^1.0.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -15675,18 +15634,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -16199,13 +16146,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/optional": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -17857,25 +17797,6 @@
       },
       "engines": {
         "node": "^16 || ^18 || >=20"
-      }
-    },
-    "node_modules/prometheus-gc-stats": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.5.tgz",
-      "integrity": "sha512-VsmpEGHt9mMZqlhL+96gz2LsaXEgu2SXQ/tiEqIBLPoUTyPORDNsEiH9DPPZHChdkTTBw3GRV1wGvqdIg4EktQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "optional": "^0.1.3"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "optionalDependencies": {
-        "gc-stats": "^1.4.0"
-      },
-      "peerDependencies": {
-        "prom-client": ">= 10 <= 14"
       }
     },
     "node_modules/promise-inflight": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "drizzle-orm": "^0.38.3",
     "execa": "^9.4.0",
     "express": "^4.18.2",
-    "express-prometheus-middleware": "^1.2.0",
     "flubber": "^0.4.2",
     "framer-motion": "^11.16.0",
     "geolib": "^3.3.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,165 +1,172 @@
-import crypto from "node:crypto";
-import prom from "@isaacs/express-prometheus-middleware";
-import { createRequestHandler } from "@react-router/express";
-import { ip as ipAddress } from "address";
-import chalk from "chalk";
-import closeWithGrace from "close-with-grace";
-import compression from "compression";
-import express from "express";
-import getPort, { portNumbers } from "get-port";
-import morgan from "morgan";
-import  { type ServerBuild } from "react-router";
+import crypto from 'node:crypto'
+import prom from '@isaacs/express-prometheus-middleware'
+import { createRequestHandler } from '@react-router/express'
+import { ip as ipAddress } from 'address'
+import chalk from 'chalk'
+import closeWithGrace from 'close-with-grace'
+import compression from 'compression'
+import express from 'express'
+import getPort, { portNumbers } from 'get-port'
+import morgan from 'morgan'
+import { type ServerBuild } from 'react-router'
 
-const MODE = process.env.NODE_ENV ?? "development";
-const IS_PROD = MODE === "production";
-const IS_DEV = MODE === "development";
+const MODE = process.env.NODE_ENV ?? 'development'
+const IS_PROD = MODE === 'production'
+const IS_DEV = MODE === 'development'
 
 const viteDevServer = IS_PROD
-  ? undefined
-  : await import("vite").then((vite) =>
-      vite.createServer({
-        server: { middlewareMode: true },
-      }),
-    );
+	? undefined
+	: await import('vite').then((vite) =>
+			vite.createServer({
+				server: { middlewareMode: true },
+			}),
+		)
 
-const app = express();
-const metricsApp = express();
+const app = express()
+const metricsApp = express()
+console.log(metricsApp)
 
 app.use(
-  prom({
-    metricsPath: "/metrics",
-    collectDefaultMetrics: true,
-    metricsApp,
-  }),
-);
+	prom({
+		metricsPath: '/metrics',
+		collectDefaultMetrics: true,
+		metricsApp,
+	}),
+)
 
 // no ending slashes for SEO reasons
 // https://github.com/epicweb-dev/epic-stack/discussions/108
-app.get("*", (req, res, next) => {
-  if (req.path.endsWith("/") && req.path.length > 1) {
-    const query = req.url.slice(req.path.length);
-    const safepath = req.path.slice(0, -1).replace(/\/+/g, "/");
-    res.redirect(302, safepath + query);
-  } else {
-    next();
-  }
-});
+app.get('*', (req, res, next) => {
+	if (req.path.endsWith('/') && req.path.length > 1) {
+		const query = req.url.slice(req.path.length)
+		const safepath = req.path.slice(0, -1).replace(/\/+/g, '/')
+		res.redirect(302, safepath + query)
+	} else {
+		next()
+	}
+})
 
-app.use(compression());
+app.use(compression())
 
 // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
-app.disable("x-powered-by");
+app.disable('x-powered-by')
 
 // handle asset requests
 if (viteDevServer) {
-  app.use(viteDevServer.middlewares);
+	app.use(viteDevServer.middlewares)
 } else {
-  // Remix fingerprints its assets so we can cache forever.
-  app.use(
-    "/assets",
-    express.static("build/client/assets", {
-      immutable: true,
-      maxAge: "1y",
-    }),
-  );
+	// Remix fingerprints its assets so we can cache forever.
+	app.use(
+		'/assets',
+		express.static('build/client/assets', {
+			immutable: true,
+			maxAge: '1y',
+		}),
+	)
 
-  // Everything else (like favicon.ico) is cached for an hour. You may want to be
-  // more aggressive with this caching.
-  app.use(express.static("build/client", { maxAge: "1h" }));
+	// Everything else (like favicon.ico) is cached for an hour. You may want to be
+	// more aggressive with this caching.
+	app.use(express.static('build/client', { maxAge: '1h' }))
 }
 
-app.get(["/img/*", "/favicons/*"], (_req, res) => {
-  // if we made it past the express.static for these, then we're missing something.
-  // So we'll just send a 404 and won't bother calling other middleware.
-  return res.status(404).send("Not found");
-});
+app.get(['/img/*', '/favicons/*'], (_req, res) => {
+	// if we made it past the express.static for these, then we're missing something.
+	// So we'll just send a 404 and won't bother calling other middleware.
+	return res.status(404).send('Not found')
+})
 
-app.use(morgan("tiny"));
+app.use(morgan('tiny'))
 
 app.use((_, res, next) => {
-  res.locals.cspNonce = crypto.randomBytes(16).toString("hex");
-  next();
-});
+	res.locals.cspNonce = crypto.randomBytes(16).toString('hex')
+	next()
+})
 
 async function getBuild() {
-  try {
-    const build = viteDevServer
-      ? await viteDevServer.ssrLoadModule("virtual:react-router/server-build")
-      : // @ts-expect-error - the file might not exist yet but it will
+	try {
+		const build = viteDevServer
+			? await viteDevServer.ssrLoadModule('virtual:react-router/server-build')
+			: // @ts-expect-error - the file might not exist yet but it will
 
-        await import("../build/server/index.js");
+				await import('../build/server/index.js')
 
-    return { build: build as unknown as ServerBuild, error: null };
-  } catch (error) {
-    // Catch error and return null to make express happy and avoid an unrecoverable crash
-    console.error("Error creating build:", error);
-    return { error: error, build: null as unknown as ServerBuild };
-  }
+		return { build: build as unknown as ServerBuild, error: null }
+	} catch (error) {
+		// Catch error and return null to make express happy and avoid an unrecoverable crash
+		console.error('Error creating build:', error)
+		return { error: error, build: null as unknown as ServerBuild }
+	}
 }
 
 app.all(
-  "*",
-  createRequestHandler({
-    getLoadContext: (_: any, res: any) => ({
-      cspNonce: res.locals.cspNonce,
-      serverBuild: getBuild(),
-    }),
-    mode: MODE,
-    build: async () => {
-      const { error, build } = await getBuild();
-      // gracefully "catch" the error
-      if (error) {
-        throw error;
-      }
-      return build;
-    },
-  }),
-);
+	'*',
+	createRequestHandler({
+		getLoadContext: (_: any, res: any) => ({
+			cspNonce: res.locals.cspNonce,
+			serverBuild: getBuild(),
+		}),
+		mode: MODE,
+		build: async () => {
+			const { error, build } = await getBuild()
+			// gracefully "catch" the error
+			if (error) {
+				throw error
+			}
+			return build
+		},
+	}),
+)
 
-const desiredPort = Number(process.env.PORT || 3000);
+const desiredPort = Number(process.env.PORT || 3000)
 const portToUse = await getPort({
-  port: portNumbers(desiredPort, desiredPort + 100),
-});
-const portAvailable = desiredPort === portToUse;
+	port: portNumbers(desiredPort, desiredPort + 100),
+})
+const portAvailable = desiredPort === portToUse
 if (!portAvailable && !IS_DEV) {
-  console.log(`⚠️ Port ${desiredPort} is not available.`);
-  process.exit(1);
+	console.log(`⚠️ Port ${desiredPort} is not available.`)
+	process.exit(1)
 }
 
 const server = app.listen(portToUse, () => {
-  if (!portAvailable && !IS_DEV) {
-    console.warn(
-      chalk.yellow(
-        `⚠️  Port ${desiredPort} is not available, using ${portToUse} instead.`,
-      ),
-    );
-  }
-  console.log(`🚀  We have liftoff!`);
-  const localUrl = `http://localhost:${portToUse}`;
-  let lanUrl: string | null = null;
-  const localIp = ipAddress() ?? "Unknown";
-  // Check if the address is a private ip
-  // https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
-  // https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/WebpackDevServerUtils.js#LL48C9-L54C10
-  if (/^10[.]|^172[.](1[6-9]|2[0-9]|3[0-1])[.]|^192[.]168[.]/.test(localIp)) {
-    lanUrl = `http://${localIp}:${portToUse}`;
-  }
+	if (!portAvailable && !IS_DEV) {
+		console.warn(
+			chalk.yellow(
+				`⚠️  Port ${desiredPort} is not available, using ${portToUse} instead.`,
+			),
+		)
+	}
+	console.log(`🚀  We have liftoff!`)
+	const localUrl = `http://localhost:${portToUse}`
+	let lanUrl: string | null = null
+	const localIp = ipAddress() ?? 'Unknown'
+	// Check if the address is a private ip
+	// https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
+	// https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/WebpackDevServerUtils.js#LL48C9-L54C10
+	if (/^10[.]|^172[.](1[6-9]|2[0-9]|3[0-1])[.]|^192[.]168[.]/.test(localIp)) {
+		lanUrl = `http://${localIp}:${portToUse}`
+	}
 
-  console.log(
-    `
-${chalk.bold("Local:")}            ${chalk.cyan(localUrl)}
-${lanUrl ? `${chalk.bold("On Your Network:")}  ${chalk.cyan(lanUrl)}` : ""}
-${chalk.bold("Press Ctrl+C to stop")}
+	console.log(
+		`
+${chalk.bold('Local:')}            ${chalk.cyan(localUrl)}
+${lanUrl ? `${chalk.bold('On Your Network:')}  ${chalk.cyan(lanUrl)}` : ''}
+${chalk.bold('Press Ctrl+C to stop')}
 		`.trim(),
-  );
-});
+	)
+})
+
+const metricsPort = process.env.METRICS_PORT || 3010
+const metricsServer = metricsApp.listen(metricsPort, () => {
+	console.log(`✅ metrics ready: http://localhost:${metricsPort}/metrics`)
+})
 
 closeWithGrace(async ({ err }) => {
-  await new Promise((resolve, reject) => {
-    server.close((e) => (e ? reject(e) : resolve("ok")));
-  });
-  if (err) {
-    console.error(chalk.red(err));
-    console.error(chalk.red(err.stack));
-  }
-});
+	await new Promise((resolve, reject) => {
+		server.close((e) => (e ? reject(e) : resolve('ok')))
+		metricsServer.close((e) => (e ? reject(e) : resolve('ok')))
+	})
+	if (err) {
+		console.error(chalk.red(err))
+		console.error(chalk.red(err.stack))
+	}
+})


### PR DESCRIPTION
This pull request includes several changes focused on code style consistency and minor functionality updates. The most significant changes involve the consistent use of single quotes for strings, the addition of logging for the metrics server, and the removal of an unused dependency.

Code style consistency:

* [`server/index.ts`](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L1-R127): Updated all string literals to use single quotes instead of double quotes for consistency. [[1]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L1-R127) [[2]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L135-R172)

Functionality updates:

* [`server/index.ts`](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L135-R172): Added logging to indicate when the metrics server is ready and listening on the specified port.

Dependency management:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L100): Removed the `express-prometheus-middleware` dependency as it is no longer used.this fixes #494 