### PR TITLE
fix: dont use overflow-y-scroll (#514)

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -109,13 +109,13 @@ export function App() {
   useChangeLanguage(data.locale);
 
   return (
-    <html lang={data.locale} dir={i18n.dir()} className={clsx("light")}>
+    <html lang={data.locale} dir={i18n.dir()} className={clsx("light", "overflow-hidden")}>
       <head>
         <Meta />
         {/* <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} /> */}
         <Links />
       </head>
-      <body className="flex h-full flex-col dark:bg-dark-background dark:text-dark-text">
+      <body className="flex h-full flex-col dark:bg-dark-background dark:text-dark-text overflow-visible">
         <Outlet />
         <Toaster />
         <ScrollRestoration />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -101,27 +101,27 @@ export default function Index() {
 
   return (
     <div
-      className="w-screen h-screen bg-white dark:bg-black scroll-snap-container"
+      className="h-screen bg-white dark:bg-black"
       style={{
         scrollSnapType: "y mandatory",
-        overflowY: "scroll",
-        height: "100vh",
+        overflowY: "auto"
       }}
     >
-      <header className="w-full z-10">
+      <header className="z-10">
         <Header />
       </header>
       <main>
         <div
           id="firstSection"
-          className="min-h-[calc(100vh-8rem)] flex flex-col justify-center mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 scroll-snap-section"
+          className="flex flex-col justify-center mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
           style={{
+            /** for some reasons not really worth debugging tailwind does not apply min-h-[calc(100vh-8rem)], so we have to use element styles here */
             minHeight: "calc(100vh - 8rem)",
             scrollSnapAlign: "center",
           }}
         >
-          <div className="flex items-center justify-between w-full px-8">
-            <div className="w-full md:w-1/2">
+          <div className="flex items-center justify-between px-8">
+            <div className="md:w-1/2">
               <h1 className="text-5xl font-bold tracking-tight text-light-green dark:text-dark-green">
                 openSenseMap
               </h1>
@@ -199,7 +199,7 @@ export default function Index() {
             )}
           </div>
           {isDesktop && (
-            <div className="w-full">
+            <div>
               <Stats {...stats} />
             </div>
           )}
@@ -209,7 +209,7 @@ export default function Index() {
           return (
             <div
               key={section.title}
-              className="h-screen flex justify-center items-center mx-32 scroll-snap-section"
+              className="h-screen flex justify-center items-center mx-32"
               style={{
                 scrollSnapAlign: "center",
               }}
@@ -219,7 +219,7 @@ export default function Index() {
           );
         })}
         <div
-          className="h-screen flex flex-col justify-center items-center mx-32 scroll-snap-section"
+          className="h-screen flex flex-col justify-center items-center mx-32"
           style={{
             scrollSnapAlign: "center",
           }}


### PR DESCRIPTION
* fix: dont use overflow-y-scroll

* refactor: remove unnecessary w-full classes

* fix: scroll behavior in chromium

* refactor: use tailwind syntax for overflow setting

* refactor: use tailwind syntax (wrong previous commit)

* fix: leave comment why element styles are necessary

---------