### PR TITLE
fix: user overflow auto on body to enable scrolling on overflowing pages

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,7 +10,9 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLoaderData, type LoaderFunctionArgs, type MetaFunction 
+  useLoaderData,
+  type LoaderFunctionArgs,
+  type MetaFunction,
 } from "react-router";
 import { useChangeLanguage } from "remix-i18next/react";
 import { Toaster } from "./components/ui/toaster";
@@ -109,13 +111,17 @@ export function App() {
   useChangeLanguage(data.locale);
 
   return (
-    <html lang={data.locale} dir={i18n.dir()} className={clsx("light", "overflow-hidden")}>
+    <html
+      lang={data.locale}
+      dir={i18n.dir()}
+      className={clsx("light", "overflow-hidden")}
+    >
       <head>
         <Meta />
         {/* <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} /> */}
         <Links />
       </head>
-      <body className="flex h-full flex-col dark:bg-dark-background dark:text-dark-text overflow-visible">
+      <body className="flex h-full flex-col dark:bg-dark-background dark:text-dark-text overflow-visible overflow-auto">
         <Outlet />
         <Toaster />
         <ScrollRestoration />


### PR DESCRIPTION
Follow up to #514 
We noticed that scrolling on the settings page wasn't possible on smaller screen devices and it turns out to reset the scrolling behavior we also need to add `overflow: auto` to the body tag.