### PR TITLE
fix: remove pinned buildx version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,6 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.9.1
 
       # Setup cache
       - name: ⚡️ Cache Docker layers


### PR DESCRIPTION
<!--
    THANK YOU FOR CONTRIBUTING!
-->

## Type of Change

<!--
    Try sticking to one type of change per pull request for easier and faster code reviews.
    Just put an x between the [] to check the box.
-->

- [x] Dependency upgrade
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
  - e.g. a fixed bug or new feature that may break something else
- [ ] New feature
- [ ] Code quality improvements
  - e.g. refactoring, documentation, tests, tooling, ...

## Implementation

<!--
    What did you change and why? How does it work?
    Are there any trade-offs or limitations?
-->

Remove pinned version of docker buildx to be up to date with the latest requirements for client versions.

## Checklist

- [x] I gave this pull request a meaningful title
- [x] My pull request is targeting the `dev` branch
- [ ] I have added documentation to my code
- [ ] I have deleted code that I have commented out

## Additional Information

<!--
    Please link any additional issue, discussion or pull request here.
    This helps us to keep everything tidy and managable.
-->
