### PR TITLE
add custom header for device api key as alternative to HTTP Authorization header

### DIFF
--- a/app/routes/api.boxes.$deviceId.$sensorId.ts
+++ b/app/routes/api.boxes.$deviceId.$sensorId.ts
@@ -15,11 +15,13 @@ export const action: ActionFunction = async ({
 				'Invalid device id or sensor id specified',
 			)
 
-		const authorization = request.headers.get('authorization')
+		const authorization =
+			request.headers.get('authorization') ??
+			request.headers.get('x-osem-device-api-key')
 		const contentType = request.headers.get('content-type') || ''
 
 		const serviceKey = request.headers.get('x-service-key')
-		const isTrustedService = await isValidServiceKey(serviceKey);
+		const isTrustedService = await isValidServiceKey(serviceKey)
 
 		if (!contentType.includes('application/json'))
 			return StandardResponse.unsupportedMediaType(
@@ -28,7 +30,13 @@ export const action: ActionFunction = async ({
 
 		const body = await request.json()
 
-		await postSingleMeasurement(deviceId, sensorId, body, authorization, isTrustedService)
+		await postSingleMeasurement(
+			deviceId,
+			sensorId,
+			body,
+			authorization,
+			isTrustedService,
+		)
 
 		return new Response('Measurement saved in box', {
 			status: 201,

--- a/app/routes/api.boxes.$deviceId.data.ts
+++ b/app/routes/api.boxes.$deviceId.data.ts
@@ -3,6 +3,21 @@ import { postNewMeasurements } from '~/lib/measurement-service.server'
 import { isValidServiceKey } from '~/models/integration.server'
 import { StandardResponse } from '~/utils/response-utils'
 
+/**
+ * @openapi
+ * /boxes/{deviceId}/data:
+ *   post:
+ *    tags:
+ *      - Sensors
+ *    summary: Post multiple new measurements in multiple formats to a box. Allows the use of csv, json array and json object notation.
+ *    description:
+ *    parameters:
+ *      - in: header
+ *        name: x-osem-device-api-key
+ *        schema:
+ *          type: string
+ *        description: alternative HTTP header for authorizing your device if you cannot use the HTTP Authorization header
+ */
 export const action: ActionFunction = async ({
 	request,
 	params,

--- a/app/routes/api.boxes.$deviceId.data.ts
+++ b/app/routes/api.boxes.$deviceId.data.ts
@@ -18,9 +18,11 @@ export const action: ActionFunction = async ({
 
 		const contentType = request.headers.get('content-type') || ''
 		const serviceKey = request.headers.get('x-service-key')
-		const authorization = request.headers.get('authorization')
+		const authorization =
+			request.headers.get('authorization') ??
+			request.headers.get('x-osem-device-api-key')
 
-		const isTrustedService = await isValidServiceKey(serviceKey);
+		const isTrustedService = await isValidServiceKey(serviceKey)
 
 		let body: any
 		if (contentType.includes('application/json')) {
@@ -38,7 +40,7 @@ export const action: ActionFunction = async ({
 			luftdaten,
 			hackair,
 			authorization: isTrustedService ? undefined : authorization,
-			isTrustedService
+			isTrustedService,
 		})
 
 		return new Response('Measurements saved in box', {

--- a/app/routes/api.devices.ts
+++ b/app/routes/api.devices.ts
@@ -416,8 +416,6 @@ async function post(request: Request, user: User) {
 		if (!rawAuthorizationHeader)
 			throw StandardResponse.unauthorized('Authorization header required')
 
-		const [, jwtString] = rawAuthorizationHeader.split(' ')
-
 		const deviceData = {
 			...body,
 			latitude,


### PR DESCRIPTION
<!--
    THANK YOU FOR CONTRIBUTING!
-->

## Type of Change

<!--
    Try sticking to one type of change per pull request for easier and faster code reviews.
    Just put an x between the [] to check the box.
-->

- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
  - e.g. a fixed bug or new feature that may break something else
- [x] New feature
- [ ] Code quality improvements
  - e.g. refactoring, documentation, tests, tooling, ...

## Implementation

<!--
    What did you change and why? How does it work?
    Are there any trade-offs or limitations?
-->
Added a fallback to api methods when no Authorization header is present.
In that case the `x-osem-device-api-key` is tried.

It turned out that ESP8266 HttpClients do not support setting the Authorization header for auths other than "Basic". If you try to set the header manually the request still fails, thus `x-osem-device-api-key` can be fallback for clients like this.

## Checklist

- [x] I gave this pull request a meaningful title
- [x] My pull request is targeting the `dev` branch
- [x] I have added documentation to my code
- [x] I have deleted code that I have commented out

## Additional Information

<!--
    Please link any additional issue, discussion or pull request here.
    This helps us to keep everything tidy and managable.
-->
