### PR TITLE
feat: load privacy policy from directus cms

### DIFF
--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,484 +1,104 @@
-export default function Privacy() {
-	;<div>
-		<h1>1. Datenschutz auf einen Blick</h1>
+import { readItem, readItems } from '@directus/sdk'
+import { useEffect, useEffectEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useRevalidator } from 'react-router'
+import { type Route } from './+types/privacy'
+import LanguageSelector from '~/components/landing/header/language-selector'
+import { MarkdownContent } from '~/components/markdown-content'
+import { i18nextOptions, type SupportedLanguage } from '~/i18next-config'
+import {
+	getDirectusClient,
+	type StaticPageTranslation,
+	type StaticPage,
+} from '~/lib/directus'
+import { getLocale } from '~/middleware/i18next'
 
-		<h2>Allgemeine Hinweise</h2>
-		<p>
-			Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit
-			Ihren personenbezogenen Daten passiert, wenn Sie unsere Website besuchen.
-			Personenbezogene Daten sind alle Daten, mit denen Sie persönlich
-			identifiziert werden können. Ausführliche Informationen zum Thema
-			Datenschutz entnehmen Sie unserer unter diesem Text aufgeführten
-			Datenschutzerklärung.
-		</p>
+export const loader = async ({ context }: Route.LoaderArgs) => {
+	const locale = getLocale(context) as SupportedLanguage
+	const locales =
+		locale == i18nextOptions.fallbackLng
+			? [locale]
+			: [locale, i18nextOptions.fallbackLng]
+	const directus = getDirectusClient()
 
-		<h2>Datenerfassung auf unserer Website</h2>
+	return directus
+		.request<StaticPage>(readItem('static_pages', 'privacy'))
+		.then((data) => {
+			return directus
+				.request<StaticPageTranslation[]>(
+					readItems('static_pages_translations', {
+						limit: locales.length,
+						filter: {
+							static_pages_slug: {
+								_eq: data.slug,
+							},
+							_or: locales.map((l) => ({
+								static_pages_languages_code: {
+									_istarts_with: l,
+								},
+							})),
+						},
+					}),
+				)
+				.then(
+					(i) =>
+						i.sort((a, b) => {
+							const aIdx = locales.findIndex((l) =>
+								a.static_pages_languages_code.startsWith(l),
+							)
+							const bIdx = locales.findIndex((l) =>
+								b.static_pages_languages_code.startsWith(l),
+							)
+							return aIdx - bIdx
+						})[0],
+				)
+		})
+}
 
-		<h3>Wer ist verantwortlich für die Datenerfassung auf dieser Website?</h3>
-		<p>
-			Die Datenverarbeitung auf dieser Website erfolgt durch den
-			Websitebetreiber. Dessen Kontaktdaten können Sie dem Impressum dieser
-			Website entnehmen.
-		</p>
+export default function Privacy({
+	loaderData: { title, content },
+}: Route.ComponentProps) {
+	const [, i18n] = useTranslation()
+	const revalidator = useRevalidator()
 
-		<h3>Wie erfassen wir Ihre Daten?</h3>
-		<p>
-			Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese mitteilen.
-			Hierbei kann es sich z.B. um Daten handeln, die Sie in ein Kontaktformular
-			eingeben.
-		</p>
-		<p>
-			Andere Daten werden automatisch beim Besuch der Website durch unsere
-			IT-Systeme erfasst. Das sind vor allem technische Daten (z.B.
-			Internetbrowser, Betriebssystem oder Uhrzeit des Seitenaufrufs). Die
-			Erfassung dieser Daten erfolgt automatisch, sobald Sie unsere Website
-			betreten.
-		</p>
+	const reloadOnLanguageChanged = useEffectEvent(async () => {
+		await revalidator.revalidate()
+	})
 
-		<h3>Wofür nutzen wir Ihre Daten?</h3>
-		<p>
-			Ein Teil der Daten wird erhoben, um eine fehlerfreie Bereitstellung der
-			Website zu gewährleisten. Andere Daten können zur Analyse Ihres
-			Nutzerverhaltens verwendet werden.
-		</p>
+	useEffect(() => {
+		i18n.on('languageChanged', reloadOnLanguageChanged)
+		return () => i18n.off('languageChanged', reloadOnLanguageChanged)
+	}, [i18n])
 
-		<h3>Welche Rechte haben Sie bezüglich Ihrer Daten?</h3>
-		<p>
-			Sie haben jederzeit das Recht unentgeltlich Auskunft über Herkunft,
-			Empfänger und Zweck Ihrer gespeicherten personenbezogenen Daten zu
-			erhalten. Sie haben außerdem ein Recht, die Berichtigung, Sperrung oder
-			Löschung dieser Daten zu verlangen. Hierzu sowie zu weiteren Fragen zum
-			Thema Datenschutz können Sie sich jederzeit unter der im Impressum
-			angegebenen Adresse an uns wenden. Des Weiteren steht Ihnen ein
-			Beschwerderecht bei der zuständigen Aufsichtsbehörde zu.
-		</p>
-
-		<h2>Analyse-Tools und Tools von Drittanbietern</h2>
-		<p>
-			Beim Besuch unserer Website kann Ihr Surf-Verhalten statistisch
-			ausgewertet werden. Das geschieht vor allem mit Cookies und mit
-			sogenannten Analyseprogrammen. Die Analyse Ihres Surf-Verhaltens erfolgt
-			in der Regel anonym; das Surf-Verhalten kann nicht zu Ihnen zurückverfolgt
-			werden. Sie können dieser Analyse widersprechen oder sie durch die
-			Nichtbenutzung bestimmter Tools verhindern. Detaillierte Informationen
-			dazu finden Sie in der folgenden Datenschutzerklärung.
-		</p>
-		<p>
-			Sie können dieser Analyse widersprechen. Über die
-			Widerspruchsmöglichkeiten werden wir Sie in dieser Datenschutzerklärung
-			informieren.
-		</p>
-
-		<h1>2. Allgemeine Hinweise und Pflichtinformationen</h1>
-
-		<h2>Datenschutz</h2>
-		<p>
-			Die Betreiber dieser Seiten nehmen den Schutz Ihrer persönlichen Daten
-			sehr ernst. Wir behandeln Ihre personenbezogenen Daten vertraulich und
-			entsprechend der gesetzlichen Datenschutzvorschriften sowie dieser
-			Datenschutzerklärung.
-		</p>
-		<p>
-			Wenn Sie diese Website benutzen, werden verschiedene personenbezogene
-			Daten erhoben. Personenbezogene Daten sind Daten, mit denen Sie persönlich
-			identifiziert werden können. Die vorliegende Datenschutzerklärung
-			erläutert, welche Daten wir erheben und wofür wir sie nutzen. Sie
-			erläutert auch, wie und zu welchem Zweck das geschieht.
-		</p>
-		<p>
-			Wir weisen darauf hin, dass die Datenübertragung im Internet (z.B. bei der
-			Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein
-			lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht
-			möglich.
-		</p>
-
-		<h2>Hinweis zur verantwortlichen Stelle</h2>
-		<p>
-			Die verantwortliche Stelle für die Datenverarbeitung auf dieser Website
-			ist:
-		</p>
-		<p>
-			[Name des Unternehmens]<br></br>
-			[Adresse]<br></br>
-			[Telefonnummer]<br></br>
-			[E-Mail-Adresse]
-		</p>
-		<p>
-			Verantwortliche Stelle ist die natürliche oder juristische Person, die
-			allein oder gemeinsam mit anderen über die Zwecke und Mittel der
-			Verarbeitung von personenbezogenen Daten (z. B. Namen, E-Mail-Adressen o.
-			Ä.) entscheidet.
-		</p>
-
-		<h2>Widerruf Ihrer Einwilligung zur Datenverarbeitung</h2>
-		<p>
-			Viele Datenverarbeitungsvorgänge sind nur mit Ihrer ausdrücklichen
-			Einwilligung möglich. Sie können eine bereits erteilte Einwilligung
-			jederzeit widerrufen. Dazu reicht eine formlose Mitteilung per E-Mail an
-			uns. Die Rechtmäßigkeit der bis zum Widerruf erfolgten Datenverarbeitung
-			bleibt vom Widerruf unberührt.
-		</p>
-
-		<h2>Beschwerderecht bei der zuständigen Aufsichtsbehörde</h2>
-		<p>
-			Im Falle von Verstößen gegen das Datenschutzrecht steht den Betroffenen
-			ein Beschwerderecht bei einer Aufsichtsbehörde, insbesondere in dem
-			Mitgliedstaat ihres gewöhnlichen Aufenthalts, ihres Arbeitsplatzes oder
-			des Orts des mutmaßlichen Verstoßes, zu. Das Beschwerderecht besteht
-			unbeschadet anderweitiger verwaltungsrechtlicher oder gerichtlicher
-			Rechtsbehelfe.
-		</p>
-
-		<h2>Recht auf Datenübertragbarkeit</h2>
-		<p>
-			Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung oder
-			in Erfüllung eines Vertrags automatisiert verarbeiten, an sich oder an
-			einen Dritten in einem gängigen, maschinenlesbaren Format aushändigen zu
-			lassen. Sofern Sie die direkte Übertragung der Daten an einen anderen
-			Verantwortlichen verlangen, erfolgt dies nur, soweit es technisch machbar
-			ist.
-		</p>
-
-		<h2>SSL- bzw. TLS-Verschlüsselung</h2>
-		<p>
-			Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung
-			vertraulicher Inhalte, wie zum Beispiel Bestellungen oder Anfragen, die
-			Sie an uns als Seitenbetreiber senden, eine SSL- bzw. TLS-Verschlüsselung.
-			Eine verschlüsselte Verbindung erkennen Sie daran, dass die Adresszeile
-			des Browsers von „http://“ auf „https://“ wechselt und an dem
-			Schloss-Symbol in Ihrer Browserzeile.
-		</p>
-		<p>
-			Wenn die SSL- bzw. TLS-Verschlüsselung aktiviert ist, können die Daten,
-			die Sie an uns übermitteln, nicht von Dritten mitgelesen werden.
-		</p>
-
-		<h2>Auskunft, Sperrung, Löschung und Berichtigung</h2>
-		<p>
-			Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit das
-			Recht auf unentgeltliche Auskunft über Ihre gespeicherten
-			personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der
-			Datenverarbeitung und ggf. ein Recht auf Berichtigung, Sperrung oder
-			Löschung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema
-			personenbezogene Daten können Sie sich jederzeit unter der im Impressum
-			angegebenen Adresse an uns wenden.
-		</p>
-
-		<h2>Widerspruch gegen Werbe-E-Mails</h2>
-		<p>
-			Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten
-			Kontaktdaten zur Übersendung von nicht ausdrücklich angeforderter Werbung
-			und Informationsmaterialien wird hiermit widersprochen. Die Betreiber der
-			Seiten behalten sich ausdrücklich rechtliche Schritte im Falle der
-			unverlangten Zusendung von Werbeinformationen, etwa durch Spam-E-Mails,
-			vor.
-		</p>
-
-		<h2>3. Datenerfassung auf unserer Website</h2>
-
-		<h3>Cookies</h3>
-		<p>
-			Die Internetseiten verwenden teilweise so genannte Cookies. Cookies
-			richten auf Ihrem Rechner keinen Schaden an und enthalten keine Viren.
-			Cookies dienen dazu, unser Angebot nutzerfreundlicher, effektiver und
-			sicherer zu machen. Cookies sind kleine Textdateien, die auf Ihrem Rechner
-			abgelegt werden und die Ihr Browser speichert.
-		</p>
-		<p>
-			Die meisten der von uns verwendeten Cookies sind so genannte
-			“Session-Cookies”. Sie werden nach Ende Ihres Besuchs automatisch
-			gelöscht. Andere Cookies bleiben auf Ihrem Endgerät gespeichert bis Sie
-			diese löschen. Diese Cookies ermöglichen es uns, Ihren Browser beim
-			nächsten Besuch wiederzuerkennen.
-		</p>
-		<p>
-			Sie können Ihren Browser so einstellen, dass Sie über das Setzen von
-			Cookies informiert werden und Cookies nur im Einzelfall erlauben, die
-			Annahme von Cookies für bestimmte Fälle oder generell ausschließen sowie
-			das automatische Löschen der Cookies beim Schließen des Browser
-			aktivieren. Bei der Deaktivierung von Cookies kann die Funktionalität
-			dieser Website eingeschränkt sein.
-		</p>
-		<p>
-			Cookies, die zur Durchführung des elektronischen Kommunikationsvorgangs
-			oder zur Bereitstellung bestimmter, von Ihnen erwünschter Funktionen (z.B.
-			Warenkorbfunktion) erforderlich sind, werden auf Grundlage von Art. 6 Abs.
-			1 lit. f DSGVO gespeichert. Der Websitebetreiber hat ein berechtigtes
-			Interesse an der Speicherung von Cookies zur technisch fehlerfreien und
-			optimierten Bereitstellung seiner Dienste. Soweit andere Cookies (z.B.
-			Cookies zur Analyse Ihres Surfverhaltens) gespeichert werden, werden diese
-			in dieser Datenschutzerklärung gesondert behandelt.
-		</p>
-
-		<h3>Server-Log-Dateien</h3>
-		<p>
-			Der Provider der Seiten erhebt und speichert automatisch Informationen in
-			so genannten Server-Log-Dateien, die Ihr Browser automatisch an uns
-			übermittelt. Dies sind:
-		</p>
-		<ul>
-			<li>Browsertyp und Browserversion</li>
-			<li>verwendetes Betriebssystem</li>
-			<li>Referrer URL</li>
-			<li>Hostname des zugreifenden Rechners</li>
-			<li>Uhrzeit der Serveranfrage</li>
-			<li>IP-Adresse</li>
-		</ul>
-		<p>
-			Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht
-			vorgenommen.
-		</p>
-		<p>
-			Grundlage für die Datenverarbeitung ist Art. 6 Abs. 1 lit. b DSGVO, der
-			die Verarbeitung von Daten zur Erfüllung eines Vertrags oder
-			vorvertraglicher Maßnahmen gestattet.
-		</p>
-
-		<h3>Kontaktformular</h3>
-		<p>
-			Wenn Sie uns per Kontaktformular Anfragen zukommen lassen, werden Ihre
-			Angaben aus dem Anfrageformular inklusive der von Ihnen dort angegebenen
-			Kontaktdaten zwecks Bearbeitung der Anfrage und für den Fall von
-			Anschlussfragen bei uns gespeichert. Diese Daten geben wir nicht ohne Ihre
-			Einwilligung weiter.
-		</p>
-		<p>
-			Die Verarbeitung der in das Kontaktformular eingegebenen Daten erfolgt
-			somit ausschließlich auf Grundlage Ihrer Einwilligung (Art. 6 Abs. 1 lit.
-			a DSGVO). Sie können diese Einwilligung jederzeit widerrufen. Dazu reicht
-			eine formlose Mitteilung per E-Mail an uns. Die Rechtmäßigkeit der bis zum
-			Widerruf erfolgten Datenverarbeitungsvorgänge bleibt vom Widerruf
-			unberührt.
-		</p>
-		<p>
-			Die von Ihnen im Kontaktformular eingegebenen Daten verbleiben bei uns,
-			bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung
-			widerrufen oder der Zweck für die Datenspeicherung entfällt (z.B. nach
-			abgeschlossener Bearbeitung Ihrer Anfrage). Zwingende gesetzliche
-			Bestimmungen – insbesondere Aufbewahrungsfristen – bleiben unberührt.
-		</p>
-
-		<h3>Registrierung auf dieser Website</h3>
-		<p>
-			Sie können sich auf unserer Website registrieren, um zusätzliche
-			Funktionen auf der Seite zu nutzen. Die dazu eingegebenen Daten verwenden
-			wir nur zum Zwecke der Nutzung des jeweiligen Angebotes oder Dienstes, für
-			den Sie sich registriert haben. Die bei der Registrierung abgefragten
-			Pflichtangaben müssen vollständig angegeben werden. Anderenfalls werden
-			wir die Registrierung ablehnen.
-		</p>
-		<p>
-			Für wichtige Änderungen etwa beim Angebotsumfang oder bei technisch
-			notwendigen Änderungen nutzen wir die bei der Registrierung angegebene
-			E-Mail-Adresse, um Sie auf diesem Wege zu informieren.
-		</p>
-		<p>
-			Die Verarbeitung der bei der Registrierung eingegebenen Daten erfolgt auf
-			Grundlage Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO). Sie können eine
-			von Ihnen erteilte Einwilligung jederzeit widerrufen. Dazu reicht eine
-			formlose Mitteilung per E-Mail an uns. Die Rechtmäßigkeit der bereits
-			erfolgten Datenverarbeitung bleibt vom Widerruf unberührt.
-		</p>
-		<p>
-			Die bei der Registrierung erfassten Daten werden von uns gespeichert,
-			solange Sie auf unserer Website registriert sind und werden anschließend
-			gelöscht. Gesetzliche Aufbewahrungsfristen bleiben unberührt.
-		</p>
-
-		<h3>Kommentarfunktion auf dieser Website</h3>
-		<p>
-			Für die Kommentarfunktion auf dieser Seite werden neben Ihrem Kommentar
-			auch Angaben zum Zeitpunkt der Erstellung des Kommentars, Ihre
-			E-Mail-Adresse und, wenn Sie nicht anonym posten, der von Ihnen gewählte
-			Nutzername gespeichert.
-		</p>
-
-		<h4>Speicherung der IP-Adresse</h4>
-		<p>
-			Unsere Kommentarfunktion speichert die IP-Adressen der Nutzer, die
-			Kommentare verfassen. Da wir Kommentare auf unserer Seite nicht vor der
-			Freischaltung prüfen, benötigen wir diese Daten, um im Falle von
-			Rechtsverletzungen wie Beleidigungen oder Propaganda gegen den Verfasser
-			vorgehen zu können.
-		</p>
-
-		<h4>Abonnieren von Kommentaren</h4>
-		<p>
-			Als Nutzer der Seite können Sie nach einer Anmeldung Kommentare
-			abonnieren. Sie erhalten eine Bestätigungsemail, um zu prüfen, ob Sie der
-			Inhaber der angegebenen E-Mail-Adresse sind. Sie können diese Funktion
-			jederzeit über einen Link in den Info-Mails abbestellen. Die im Rahmen des
-			Abonnierens von Kommentaren eingegebenen Daten werden in diesem Fall
-			gelöscht; wenn Sie diese Daten für andere Zwecke und an anderer Stelle
-			(z.B. Newsletterbestellung) an uns übermittelt haben, verbleiben die
-			jedoch bei uns.
-		</p>
-
-		<h4>Speicherdauer der Kommentare</h4>
-		<p>
-			Die Kommentare und die damit verbundenen Daten (z.B. IP-Adresse) werden
-			gespeichert und verbleiben auf unserer Website, bis der kommentierte
-			Inhalt vollständig gelöscht wurde oder die Kommentare aus rechtlichen
-			Gründen gelöscht werden müssen (z.B. beleidigende Kommentare).
-		</p>
-
-		<h4>Rechtsgrundlage</h4>
-		<p>
-			Die Speicherung der Kommentare erfolgt auf Grundlage Ihrer Einwilligung
-			(Art. 6 Abs. 1 lit. a DSGVO). Sie können eine von Ihnen erteilte
-			Einwilligung jederzeit widerrufen. Dazu reicht eine formlose Mitteilung
-			per E-Mail an uns. Die Rechtmäßigkeit der bereits erfolgten
-			Datenverarbeitungsvorgänge bleibt vom Widerruf unberührt.
-		</p>
-
-		<h3>Verarbeiten von Daten (Kunden- und Vertragsdaten)</h3>
-		<p>
-			Wir erheben, verarbeiten und nutzen personenbezogene Daten nur, soweit sie
-			für die Begründung, inhaltliche Ausgestaltung oder Änderung des
-			Rechtsverhältnisses erforderlich sind (Bestandsdaten). Dies erfolgt auf
-			Grundlage von Art. 6 Abs. 1 lit. b DSGVO, der die Verarbeitung von Daten
-			zur Erfüllung eines Vertrags oder vorvertraglicher Maßnahmen gestattet.
-			Personenbezogene Daten über die Inanspruchnahme unserer Internetseiten
-			(Nutzungsdaten) erheben, verarbeiten und nutzen wir nur, soweit dies
-			erforderlich ist, um dem Nutzer die Inanspruchnahme des Dienstes zu
-			ermöglichen oder abzurechnen.
-		</p>
-		<p>
-			Die erhobenen Kundendaten werden nach Abschluss des Auftrags oder
-			Beendigung der Geschäftsbeziehung gelöscht. Gesetzliche
-			Aufbewahrungsfristen bleiben unberührt.
-		</p>
-
-		<h2>4. Analyse Tools und Werbung</h2>
-
-		<h3>Matomo (ehemals Piwik)</h3>
-		<p>
-			Diese Website benutzt den Open Source Webanalysedienst Matomo. Matomo
-			verwendet so genannte "Cookies". Das sind Textdateien, die auf Ihrem
-			Computer gespeichert werden und die eine Analyse der Benutzung der Website
-			durch Sie ermöglichen. Dazu werden die durch den Cookie erzeugten
-			Informationen über die Benutzung dieser Website auf unserem Server
-			gespeichert. Die IP-Adresse wird vor der Speicherung anonymisiert.
-		</p>
-		<p>Matomo-Cookies verbleiben auf Ihrem Endgerät, bis Sie sie löschen.</p>
-		<p>
-			Die Speicherung von Matomo-Cookies erfolgt auf Grundlage von Art. 6 Abs. 1
-			lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der
-			anonymisierten Analyse des Nutzerverhaltens, um sowohl sein Webangebot als
-			auch seine Werbung zu optimieren.
-		</p>
-		<p>
-			Die durch den Cookie erzeugten Informationen über die Benutzung dieser
-			Website werden nicht an Dritte weitergegeben. Sie können die Speicherung
-			der Cookies durch eine entsprechende Einstellung Ihrer Browser-Software
-			verhindern; wir weisen Sie jedoch hin, dass Sie in diesem Fall
-			gegebenenfalls nicht sämtliche Funktionen dieser Website vollumfänglich
-			werden nutzen können.
-		</p>
-		<p>
-			Wenn Sie mit der Speicherung und Nutzung Ihrer Daten nicht einverstanden
-			sind, können Sie die Speicherung und Nutzung hier deaktivieren. In diesem
-			Fall wird in Ihrem Browser ein Opt-Out-Cookie hinterlegt, der verhindert,
-			dass Matomo Nutzungsdaten speichert. Wenn Sie Ihre Cookies löschen, hat
-			dies zur Folge, dass auch das Matomo Opt-Out-Cookie gelöscht wird. Das
-			Opt-Out muss bei einem erneuten Besuch unserer Seite wieder aktiviert
-			werden.
-		</p>
-
-		<h2>5. Newsletter</h2>
-
-		<h3>Newsletterdaten</h3>
-		<p>
-			Wenn Sie den auf der Website angebotenen Newsletter beziehen möchten,
-			benötigen wir von Ihnen eine E-Mail-Adresse sowie Informationen, welche
-			uns die Überprüfung gestatten, dass Sie der Inhaber der angegebenen
-			E-Mail-Adresse sind und mit dem Empfang des Newsletters einverstanden
-			sind. Weitere Daten werden nicht bzw. nur auf freiwilliger Basis erhoben.
-			Diese Daten verwenden wir ausschließlich für den Versand der angeforderten
-			Informationen und geben diese nicht an Dritte weiter.
-		</p>
-		<p>
-			Die Verarbeitung der in das Newsletteranmeldeformular eingegebenen Daten
-			erfolgt ausschließlich auf Grundlage Ihrer Einwilligung (Art. 6 Abs. 1
-			lit. a DSGVO). Die erteilte Einwilligung zur Speicherung der Daten, der
-			E-Mail-Adresse sowie deren Nutzung zum Versand des Newsletters können Sie
-			jederzeit widerrufen, etwa über den "Austragen"-Link im Newsletter. Die
-			Rechtmäßigkeit der bereits erfolgten Datenverarbeitungsvorgänge bleibt vom
-			Widerruf unberührt.
-		</p>
-		<p>
-			Die von Ihnen zum Zwecke des Newsletter-Bezugs bei uns hinterlegten Daten
-			werden von uns bis zu Ihrer Austragung aus dem Newsletter gespeichert und
-			nach der Abbestellung des Newsletters gelöscht. Daten, die zu anderen
-			Zwecken bei uns gespeichert wurden (z.B. E-Mail-Adressen für den
-			Mitgliederbereich) bleiben hiervon unberührt.
-		</p>
-
-		<h3>MailChimp</h3>
-		<p>
-			Diese Website nutzt die Dienste von MailChimp für den Versand von
-			Newslettern. Anbieter ist die Rocket Science Group LLC, 675 Ponce De Leon
-			Ave NE, Suite 5000, Atlanta, GA 30308, USA.
-		</p>
-		<p>
-			MailChimp ist ein Dienst, mit dem u.a. der Versand von Newslettern
-			organisiert und analysiert werden kann. Wenn Sie Daten zum Zwecke des
-			Newsletterbezugs eingeben (z.B. E-Mail-Adresse), werden diese auf den
-			Servern von MailChimp in den USA gespeichert.
-		</p>
-		<p>
-			MailChimp verfügt über eine Zertifizierung nach dem
-			“EU-US-Privacy-Shield”. Der “Privacy-Shield” ist ein Übereinkommen
-			zwischen der Europäischen Union (EU) und den USA, das die Einhaltung
-			europäischer Datenschutzstandards in den USA gewährleisten soll.
-		</p>
-		<p>
-			Mit Hilfe von MailChimp können wir unsere Newsletterkampagnen analysieren.
-			Wenn Sie eine mit MailChimp versandte E-Mail öffnen, verbindet sich eine
-			in der E-Mail enthaltene Datei (sog. web-beacon) mit den Servern von
-			MailChimp in den USA. So kann festgestellt werden, ob eine
-			Newsletter-Nachricht geöffnet und welche Links ggf. angeklickt wurden.
-			Außerdem werden technische Informationen erfasst (z.B. Zeitpunkt des
-			Abrufs, IP-Adresse, Browsertyp und Betriebssystem). Diese Informationen
-			können nicht dem jeweiligen Newsletter-Empfänger zugeordnet werden. Sie
-			dienen ausschließlich der statistischen Analyse von Newsletterkampagnen.
-			Die Ergebnisse dieser Analysen können genutzt werden, um künftige
-			Newsletter besser an die Interessen der Empfänger anzupassen.
-		</p>
-		<p>
-			Wenn Sie keine Analyse durch MailChimp wollen, müssen Sie den Newsletter
-			abbestellen. Hierfür stellen wir in jeder Newsletternachricht einen
-			entsprechenden Link zur Verfügung. Des Weiteren können Sie den Newsletter
-			auch direkt auf der Website abbestellen.
-		</p>
-		<p>
-			Die Datenverarbeitung erfolgt auf Grundlage Ihrer Einwilligung (Art. 6
-			Abs. 1 lit. a DSGVO). Sie können diese Einwilligung jederzeit widerrufen,
-			indem Sie den Newsletter abbestellen. Die Rechtmäßigkeit der bereits
-			erfolgten Datenverarbeitungsvorgänge bleibt vom Widerruf unberührt.
-		</p>
-		<p>
-			Die von Ihnen zum Zwecke des Newsletter-Bezugs bei uns hinterlegten Daten
-			werden von uns bis zu Ihrer Austragung aus dem Newsletter gespeichert und
-			nach der Abbestellung des Newsletters sowohl von unseren Servern als auch
-			von den Servern von MailChimp gelöscht. Daten, die zu anderen Zwecken bei
-			uns gespeichert wurden (z.B. E-Mail-Adressen für den Mitgliederbereich)
-			bleiben hiervon unberührt.
-		</p>
-
-		<h3>Abschluss eines Data-Processing-Agreements</h3>
-		<p>
-			Wir haben ein sog. „Data-Processing-Agreement“ mit MailChimp
-			abgeschlossen, in dem wir MailChimp verpflichten, die Daten unserer Kunden
-			zu schützen und sie nicht an Dritte weiterzugeben. Dieser Vertrag kann
-			unter folgendem Link eingesehen werden:{' '}
-			<a
-				href="https://mailchimp.com/legal/forms/data-processing-agreement/sample-agreement/"
-				target="_blank"
-			>
-				https://mailchimp.com/legal/forms/data-processing-agreement/sample-agreement/
-			</a>
-			.
-		</p>
-	</div>
+	return (
+		<>
+			<header>
+				<nav className="relative mx-auto flex h-16 max-w-7xl justify-between py-6 dark:border-gray-300 dark:bg-black">
+					<div className="container flex flex-wrap items-center justify-between px-4 font-serif">
+						<div className="flex max-w-(--breakpoint-xl) flex-wrap items-center justify-between">
+							<Link to="/" className="flex items-center md:pr-10">
+								<img
+									src="/img/logo.png"
+									className="mr-3 h-6 sm:h-9"
+									alt="osem Logo"
+								/>
+								<span className="text-light-green dark:text-dark-green hidden self-center text-xl whitespace-nowrap md:block">
+									openSenseMap
+								</span>
+							</Link>
+						</div>
+						<div>
+							<div className="flex items-center justify-center md:order-2">
+								<LanguageSelector />
+							</div>
+						</div>
+					</div>
+				</nav>
+			</header>
+			<main className="mx-auto mt-8 flex max-w-7xl flex-col justify-center px-4 sm:px-6 lg:px-8">
+				<h1 className="my-4 text-4xl">{title}</h1>
+				<MarkdownContent>{content}</MarkdownContent>
+			</main>
+		</>
+	)
 }


### PR DESCRIPTION
## Type of Change

Load privacy policy from our directus CMS instead of having it in the code itself. I basically copied the code from the imprint page and thus introduced some code duplication. Since we are only loading two pages from directus at the moment, I'd argue that's still acceptable.

- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
  - e.g. a fixed bug or new feature that may break something else
- [x] New feature
- [ ] Code quality improvements
  - e.g. refactoring, documentation, tests, tooling, ...

## Implementation

Copy pasta from `imprint.tsx` 🍝 

## Checklist

- [x] I gave this pull request a meaningful title
- [x] My pull request is targeting the `dev` branch
- [ ] I have added documentation to my code
- [ ] I have deleted code that I have commented out

## Additional Information

- This PR closes #896 
