### PR TITLE
fix: disable btn while navigation state is loading after submission

### DIFF
--- a/app/components/device/new/new-device-stepper.tsx
+++ b/app/components/device/new/new-device-stepper.tsx
@@ -128,7 +128,7 @@ export default function NewDeviceStepper() {
 	const { t } = useTranslation('newdevice')
 	const [isFirst, setIsFirst] = useState(false)
 	const navigation = useNavigation()
-	const isSubmitting = navigation.state === 'submitting'
+	const isSubmitting = navigation.state !== 'idle'
 
 	useEffect(() => {
 		setIsFirst(stepper.state.isFirst)


### PR DESCRIPTION
<!--
    THANK YOU FOR CONTRIBUTING!
-->

## Type of Change

<!--
    Try sticking to one type of change per pull request for easier and faster code reviews.
    Just put an x between the [] to check the box.
-->

- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
  - e.g. a fixed bug or new feature that may break something else
- [ ] New feature
- [ ] Code quality improvements
  - e.g. refactoring, documentation, tests, tooling, ...

## Implementation

The button to submit the form was only disabled during the actual form submission, so the button could become reenabled during the redirect phase where navigation / loaders are awaited before the next page renders.

## Checklist

- [ ] I gave this pull request a meaningful title
- [ ] My pull request is targeting the `dev` branch
- [ ] I have added documentation to my code
- [ ] I have deleted code that I have commented out

## Additional Information

<!--
    Please link any additional issue, discussion or pull request here.
    This helps us to keep everything tidy and managable.
-->

- This PR closes #
