### PR TITLE
Remove ts-ignore for single measurement body

### DIFF
--- a/app/lib/openapi/schemas/location.ts
+++ b/app/lib/openapi/schemas/location.ts
@@ -13,6 +13,27 @@ export const CoordinatesWithHeightSchema = z
 		example: [7.68123, 51.9123, 66.6],
 	})
 
+export const LongitudeLatitudeLocationObjectSchema = z
+	.object({
+		longitude: z.number().meta({
+			description: 'Longitude',
+			example: 7.68123,
+		}),
+		latitude: z.number().meta({
+			description: 'Latitude',
+			example: 51.9123,
+		}),
+		height: z.number().optional().meta({
+			description: 'Height above ground in meters.',
+			example: 66.6,
+		}),
+	})
+	.meta({
+		id: 'LongitudeLatitudeLocationObject',
+		description:
+			'Location object with longitude, latitude, and optional height.',
+	})
+
 export const LocationObjectSchema = z
 	.object({
 		lng: z.number().meta({
@@ -33,26 +54,15 @@ export const LocationObjectSchema = z
 		description:
 			'Location object with longitude, latitude, and optional height.',
 	})
-
-export const LongitudeLatitudeLocationObjectSchema = z
-	.object({
-		longitude: z.number().meta({
-			description: 'Longitude',
-			example: 7.68123,
-		}),
-		latitude: z.number().meta({
-			description: 'Latitude',
-			example: 51.9123,
-		}),
-		height: z.number().optional().meta({
-			description: 'Height above ground in meters.',
-			example: 66.6,
-		}),
-	})
-	.meta({
-		id: 'LongitudeLatitudeLocationObject',
-		description:
-			'Location object with longitude, latitude, and optional height.',
+	.or(LongitudeLatitudeLocationObjectSchema)
+	.transform((location) => {
+		if ('lng' in location) return location
+		else
+			return {
+				lng: location.longitude,
+				lat: location.latitude,
+				height: location.height,
+			}
 	})
 
 export const GeoJsonPointSchema = z

--- a/app/lib/openapi/schemas/measurement.ts
+++ b/app/lib/openapi/schemas/measurement.ts
@@ -1,9 +1,5 @@
 import * as z from 'zod/v4'
-import {
-	CoordinatesWithHeightSchema,
-	LocationObjectSchema,
-	LongitudeLatitudeLocationObjectSchema,
-} from './location'
+import { CoordinatesWithHeightSchema, LocationObjectSchema } from './location'
 
 export const MeasurementValueSchema = z.number().nullable().meta({
 	description: 'Measured value',
@@ -20,11 +16,7 @@ export const MeasurementLocationIdSchema = z
 	})
 
 export const MeasurementLocationSchema = z
-	.union([
-		CoordinatesWithHeightSchema,
-		LocationObjectSchema,
-		LongitudeLatitudeLocationObjectSchema,
-	])
+	.union([CoordinatesWithHeightSchema, LocationObjectSchema])
 	.meta({
 		id: 'MeasurementLocation',
 		description:

--- a/app/routes/api.boxes.$deviceId.$sensorId.ts
+++ b/app/routes/api.boxes.$deviceId.$sensorId.ts
@@ -223,7 +223,6 @@ export const action = async ({
 		await postSingleMeasurement(
 			parsedParams.deviceId,
 			parsedParams.sensorId,
-			//@ts-ignore
 			parsedBody,
 			authorization,
 			isTrustedService,

--- a/app/services/measurement-service.server.ts
+++ b/app/services/measurement-service.server.ts
@@ -74,7 +74,7 @@ interface SingleMeasurementBody {
 	value: number
 	createdAt?: string
 	location?:
-		| [number, number, number]
+		| [number, number, number?]
 		| { lat: number; lng: number; height?: number }
 }
 


### PR DESCRIPTION
<!--
    THANK YOU FOR CONTRIBUTING!
-->

## Type of Change

<!--
    Try sticking to one type of change per pull request for easier and faster code reviews.
    Just put an x between the [] to check the box.
-->

- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
  - e.g. a fixed bug or new feature that may break something else
- [ ] New feature
- [x] Code quality improvements
  - e.g. refactoring, documentation, tests, tooling, ...

## Implementation

<!--
    What did you change and why? How does it work?
    Are there any trade-offs or limitations?
-->
I added a transform to the `LongitudeLatitudeLocationObjectSchema` such that compatible types fall out of the schema for the `SingleMeasurementBody` in order to get rid of the `ts-ignore`.

## Checklist

- [x] I gave this pull request a meaningful title
- [x] My pull request is targeting the `dev` branch
- [x] I have added documentation to my code
- [x] I have deleted code that I have commented out

## Additional Information

<!--
    Please link any additional issue, discussion or pull request here.
    This helps us to keep everything tidy and managable.
-->

- This PR closes #
